### PR TITLE
Update "in" operator

### DIFF
--- a/src/Traits/QueryableBlock.php
+++ b/src/Traits/QueryableBlock.php
@@ -55,11 +55,8 @@ trait QueryableBlock
                 '<=' => $elementToCheck->get($field) <= $value,
                 '!=' => $elementToCheck->get($field) != $value,
                 '!==' => $elementToCheck->get($field) !== $value,
-                'like' => self::like($elementToCheck->get($field), $value),
-                'in' => (is_array($elementToCheck->get($field)) && is_string($value) 
-                            ? in_array($value, $elementToCheck->get($field))
-                            : in_array($elementToCheck->get($field), $value)
-                            ),
+                'in' => in_array($value, $elementToCheck->get($field)),
+                'has' => in_array($elementToCheck->get($field), $value),
                 default => $elementToCheck->get($field) === $value,
             };
             if ($found) {

--- a/src/Traits/QueryableBlock.php
+++ b/src/Traits/QueryableBlock.php
@@ -56,7 +56,10 @@ trait QueryableBlock
                 '!=' => $elementToCheck->get($field) != $value,
                 '!==' => $elementToCheck->get($field) !== $value,
                 'like' => self::like($elementToCheck->get($field), $value),
-                'in' => in_array($value, $elementToCheck->get($field)),
+                'in' => (is_array($elementToCheck->get($field)) && is_string($value) 
+                            ? in_array($value, $elementToCheck->get($field))
+                            : in_array($elementToCheck->get($field), $value)
+                            ),
                 default => $elementToCheck->get($field) === $value,
             };
             if ($found) {


### PR DESCRIPTION
Thanks Roberto-- love the project.  I made this tweak to my code, think it might help others. 

Currently the 'in' operator tests if a value is in an array field.  This update still allows that, but also 
allows people to test if a string field is in an array of their choosing.
(it allows users to effectively do a simple 'or' test)

eg
$url = "https://dummyjson.com/posts";
$posts = Block
    ::fromJsonUrl($url)
    ->getBlock("posts");
//if field id is in this array
$someOddPosts = $posts->where("id", "in", array(1,3,5,7,9));

// if the string "love" in the tags array field
$lovePosts = $posts->where("tags", "in", "love");

(I can update this further, eg testing if a string, should maybe also allow numeric,bool??  or just not an array??  If two arrays, perhaps could get intersection) -- but that was feeling complex