### PR TITLE
Add getIntStrict method to TypeableBlock trait

### DIFF
--- a/src/Traits/TypeableBlock.php
+++ b/src/Traits/TypeableBlock.php
@@ -38,6 +38,26 @@ trait TypeableBlock
     }
 
     /**
+     * Return a forced integer value from the get() method
+     * @param int|string $key the field key, can be nested for example "0.author.id"
+     * @param int $defaultValue the default integer value returned if no value is found
+     * @param non-empty-string $charNestedKey for nested field the . character is the default
+     */
+    public function getIntStrict(int|string $key, int $defaultValue = 0, string $charNestedKey = "."): int
+    {
+        $returnValue = $this->get($key, $defaultValue, $charNestedKey);
+
+        if ($returnValue === null) {
+            return $defaultValue;
+        }
+
+        if (is_scalar($returnValue)) {
+            return intval($returnValue);
+        }
+
+        return $defaultValue;
+    }
+    /**
      * Return a forced boolean value from the get() method
      * @param int|string $key the filed key , can be nested for example "commits.0.editable"
      * @param bool|null $defaultValue the default value returned if no value is found


### PR DESCRIPTION
Introduces getIntStrict to enforce integer return values from the get() method, handling nested keys and default values. This improves type safety when retrieving integer fields.